### PR TITLE
[Minor] Disable error in pipeline. 

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -41,4 +41,5 @@ jobs:
         PROJECT_VERSION=${{ needs.maven-build.outputs.version }}
       USES_MAVEN: true
       JAVA_VERSION: 21
+      DOWNLOAD_SBOM: false
     secrets: inherit


### PR DESCRIPTION
 Adding variable that disables SBOM download step (used by FE in pipeline) that causes red-herring error in the git build pipeline.
 
 
![Screenshot 2024-10-10 at 12 13 24](https://github.com/user-attachments/assets/f7442dfd-d88e-4e7a-9560-1a3b2656320c)
