### PR TITLE
[Minor] Improve random string generation

### DIFF
--- a/entity-resolver-configurations/ies/src/test/java/io/telicent/smart/cache/canonical/configuration/TestCanonicalTypeConfigurationFields.java
+++ b/entity-resolver-configurations/ies/src/test/java/io/telicent/smart/cache/canonical/configuration/TestCanonicalTypeConfigurationFields.java
@@ -108,7 +108,7 @@ public class TestCanonicalTypeConfigurationFields {
     @Test(dataProvider = "mismatchedTypes")
     public void equals_test_mismatches(String type, List<String> otherTypes) {
         // given
-        String matchingName = RandomStringUtils.secure().nextAscii(6);
+        String matchingName = RandomStringUtils.secure().nextAlphanumeric(6);
 
         CanonicalTypeConfiguration
                 originalConfiguration = CanonicalTypeConfiguration.loadFromString(String.format(JSON_STRING, matchingName, type));

--- a/entity-resolver-configurations/ies/src/test/java/io/telicent/smart/cache/canonical/configuration/TestCanonicalTypeConfigurationFields.java
+++ b/entity-resolver-configurations/ies/src/test/java/io/telicent/smart/cache/canonical/configuration/TestCanonicalTypeConfigurationFields.java
@@ -108,7 +108,7 @@ public class TestCanonicalTypeConfigurationFields {
     @Test(dataProvider = "mismatchedTypes")
     public void equals_test_mismatches(String type, List<String> otherTypes) {
         // given
-        String matchingName = RandomStringUtils.random(6);
+        String matchingName = RandomStringUtils.secure().nextAscii(6);
 
         CanonicalTypeConfiguration
                 originalConfiguration = CanonicalTypeConfiguration.loadFromString(String.format(JSON_STRING, matchingName, type));

--- a/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/TestElasticSearchEntityResolver.java
+++ b/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/TestElasticSearchEntityResolver.java
@@ -39,8 +39,8 @@ public class TestElasticSearchEntityResolver {
     @Test
     public void test_getIndexToUse_chooseOverrideIfAvailable() {
         // given
-        String randomDefaultIndex = RandomStringUtils.secure().nextAscii(6);
-        String randomOverrideIndex = RandomStringUtils.secure().nextAscii(6);
+        String randomDefaultIndex = RandomStringUtils.secure().nextAlphanumeric(6);
+        String randomOverrideIndex = RandomStringUtils.secure().nextAlphanumeric(6);
 
         CanonicalTypeConfiguration
                 override = CanonicalTypeConfiguration.loadFromString(HAPPY_STRING);
@@ -60,7 +60,7 @@ public class TestElasticSearchEntityResolver {
     @Test
     public void test_getIndexToUse_nullOverride() {
         // given
-        String randomDefaultIndex = RandomStringUtils.secure().nextAscii(6);
+        String randomDefaultIndex = RandomStringUtils.secure().nextAlphanumeric(6);
         try (ElasticSearchEntityResolver resolver = new ElasticSearchEntityResolver("host", 0, randomDefaultIndex)) {
             // when
             String result = resolver.getIndexToUse(null, null);
@@ -74,7 +74,7 @@ public class TestElasticSearchEntityResolver {
     @Test
     public void test_getIndexToUse_nullOverrideIndex() {
         // given
-        String randomDefaultIndex = RandomStringUtils.secure().nextAscii(6);
+        String randomDefaultIndex = RandomStringUtils.secure().nextAlphanumeric(6);
         CanonicalTypeConfiguration
                 override = CanonicalTypeConfiguration.loadFromString(HAPPY_STRING);
         Assert.assertNotNull(override);

--- a/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/TestElasticSearchEntityResolver.java
+++ b/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/TestElasticSearchEntityResolver.java
@@ -39,8 +39,8 @@ public class TestElasticSearchEntityResolver {
     @Test
     public void test_getIndexToUse_chooseOverrideIfAvailable() {
         // given
-        String randomDefaultIndex = RandomStringUtils.random(6);
-        String randomOverrideIndex = RandomStringUtils.random(6);
+        String randomDefaultIndex = RandomStringUtils.secure().nextAscii(6);
+        String randomOverrideIndex = RandomStringUtils.secure().nextAscii(6);
 
         CanonicalTypeConfiguration
                 override = CanonicalTypeConfiguration.loadFromString(HAPPY_STRING);
@@ -60,7 +60,7 @@ public class TestElasticSearchEntityResolver {
     @Test
     public void test_getIndexToUse_nullOverride() {
         // given
-        String randomDefaultIndex = RandomStringUtils.random(6);
+        String randomDefaultIndex = RandomStringUtils.secure().nextAscii(6);
         try (ElasticSearchEntityResolver resolver = new ElasticSearchEntityResolver("host", 0, randomDefaultIndex)) {
             // when
             String result = resolver.getIndexToUse(null, null);
@@ -74,7 +74,7 @@ public class TestElasticSearchEntityResolver {
     @Test
     public void test_getIndexToUse_nullOverrideIndex() {
         // given
-        String randomDefaultIndex = RandomStringUtils.random(6);
+        String randomDefaultIndex = RandomStringUtils.secure().nextAscii(6);
         CanonicalTypeConfiguration
                 override = CanonicalTypeConfiguration.loadFromString(HAPPY_STRING);
         Assert.assertNotNull(override);

--- a/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestDynamicSimilarityQueryGenerator.java
+++ b/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestDynamicSimilarityQueryGenerator.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class TestDynamicSimilarityQueryGenerator {
 
     private static final String HAPPY_PATH = "src/test/resources/dynamic_config_sample.yml";
-    private static final String RANDOM_ID = RandomStringUtils.secure().nextAscii(6);
+    private static final String RANDOM_ID = RandomStringUtils.secure().nextAlphanumeric(6);
 
     @Test
     public void test_generateQuery_invalidConfig() {

--- a/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestDynamicSimilarityQueryGenerator.java
+++ b/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestDynamicSimilarityQueryGenerator.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class TestDynamicSimilarityQueryGenerator {
 
     private static final String HAPPY_PATH = "src/test/resources/dynamic_config_sample.yml";
-    private static final String RANDOM_ID = RandomStringUtils.random(6);
+    private static final String RANDOM_ID = RandomStringUtils.secure().nextAscii(6);
 
     @Test
     public void test_generateQuery_invalidConfig() {

--- a/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestQueryGeneratorResolver.java
+++ b/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestQueryGeneratorResolver.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
 
 public class TestQueryGeneratorResolver {
     private static final String HAPPY_PATH = "src/test/resources/dynamic_config_sample.yml";
-    private static final String RANDOM_ID = RandomStringUtils.random(6);
+    private static final String RANDOM_ID = RandomStringUtils.secure().nextAscii(6);
 
     private static final String CANONICAL_TYPE = "canonicaltype";
 

--- a/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestQueryGeneratorResolver.java
+++ b/entity-resolver-elastic/src/test/java/io/telicent/smart/cache/entity/resolver/elastic/similarity/TestQueryGeneratorResolver.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
 
 public class TestQueryGeneratorResolver {
     private static final String HAPPY_PATH = "src/test/resources/dynamic_config_sample.yml";
-    private static final String RANDOM_ID = RandomStringUtils.secure().nextAscii(6);
+    private static final String RANDOM_ID = RandomStringUtils.secure().nextAlphanumeric(6);
 
     private static final String CANONICAL_TYPE = "canonicaltype";
 


### PR DESCRIPTION
Random strings are a little **too** random for Jackson and so were causing failures. Better to be random but still alphanumeric to get the desired affect but in a safe manner.